### PR TITLE
Do not try and include empty $multipath::my_class

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -389,7 +389,7 @@ class multipath (
 
 
   ### Include custom class if $my_class is set
-  if $multipath::my_class {
+  if $multipath::my_class and $multipath::my_class != '' {
     include $multipath::my_class
   }
 


### PR DESCRIPTION
Avoid error in site role spec tests, maybe due to strict variables?:

error during compilation: Evaluation Error: Error while evaluating a Function Call, Cannot use empty string as a class name (file: /Users/tdockendorf/puppet/osc-puppetmaster-conf/modules/multipath/manifests/init.pp, line: 393, column: 5)

Resolves #4 
